### PR TITLE
Ruby Meetup

### DIFF
--- a/exercism/ruby/meetup/meetup.rb
+++ b/exercism/ruby/meetup/meetup.rb
@@ -1,7 +1,68 @@
-=begin
-Write your code for the 'Meetup' exercise in this file. Make the tests in
-`meetup_test.rb` pass.
+# Write your code for the 'Meetup' exercise in this file. Make the tests in
+# `meetup_test.rb` pass.
+#
+# To get started with TDD, see the `README.md` file in your
+# `ruby/meetup` directory.
 
-To get started with TDD, see the `README.md` file in your
-`ruby/meetup` directory.
-=end
+require 'Date'
+
+# Meetup Class determines the dates of meetings
+class Meetup
+  def initialize(month, year)
+    @month = month
+    @year = year
+  end
+
+  def day(day_of_week, descriptor)
+    first_occurance = get_first_occurance(day_of_week)
+
+    # handle descriptors
+    case descriptor
+    when :first then first_occurance
+    when :second then first_occurance + 7
+    when :third then first_occurance + 14
+    when :fourth then first_occurance + 21
+    when :last
+      # Aim high and work backwards until the months are the same
+      if (first_occurance + 28).mon == first_occurance.mon
+        first_occurance + 28
+      elsif (first_occurance + 21).mon == first_occurance.mon
+        first_occurance + 21
+      else
+        first_occurance + 14
+      end
+    when :teenth
+      # Test the sencond and third occurance of the day
+      (1..2).each do |counter|
+        loop_day_of_week = first_occurance + (counter * 7)
+        return first_occurance + (counter * 7) if loop_day_of_week.day >= 13
+      end
+    end
+  end
+
+  private
+
+  def get_first_occurance(day_of_week)
+    # Day of week to number
+    day_number = nil
+    case day_of_week
+    when :monday then day_number = 1
+    when :tuesday then day_number = 2
+    when :wednesday then day_number = 3
+    when :thursday then day_number = 4
+    when :friday then day_number = 5
+    when :saturday then day_number = 6
+    when :sunday then day_number = 7
+    end
+
+    # Get the first of the month
+    first_of_month = Date.new(@year, @month, 1)
+
+    # Find first occurance of day_of_week
+    first_occurance = nil
+    7.times do |counter|
+      first_occurance = first_of_month + counter if (first_of_month + counter).cwday == day_number
+    end
+    first_occurance
+  end
+end

--- a/exercism/ruby/meetup/meetup.rb
+++ b/exercism/ruby/meetup/meetup.rb
@@ -4,7 +4,7 @@
 # To get started with TDD, see the `README.md` file in your
 # `ruby/meetup` directory.
 
-require 'Date'
+require 'date'
 
 # Meetup Class determines the dates of meetings
 class Meetup
@@ -16,56 +16,44 @@ class Meetup
 
   # get meeting date
   def day(day_of_week, descriptor)
-    # Get first occurance of x day of the week in @month @year
-    first_occurance = get_first_occurance(day_of_week)
+    # Get all occurances of xday of the week in @month @year
+    all_occurances = get_all_occurances(day_of_week)
 
-    # handle descriptors
-    case descriptor
-    # Simple handling of first to fourth
-    when :first then first_occurance
-    when :second then first_occurance + 7
-    when :third then first_occurance + 14
-    when :fourth then first_occurance + 21
-
-    when :last
-      # Aim high and work backwards until the months are the same
-      if (first_occurance + 28).mon == first_occurance.mon
-        first_occurance + 28
-      else
-        first_occurance + 21
-      end
-    when :teenth
-      # Test the sencond and third occurance of xday
-      (1..2).each do |counter|
-        loop_day_of_week = first_occurance + (counter * 7)
-        return first_occurance + (counter * 7) if loop_day_of_week.day >= 13
+    # Return the 2nd or 3rd week
+    if descriptor == :teenth
+      all_occurances[1..2].each do |test_day|
+        return test_day if test_day.day >= 13
       end
     end
+
+    # Everything else
+    index = { first: 0, second: 1, third: 2, fourth: 3, last: -1 }
+    all_occurances[index[descriptor]]
   end
 
   private
 
   def get_first_occurance(day_of_week)
-    # Day of week to number
-    day_number = nil
-    case day_of_week
-    when :monday then day_number = 1
-    when :tuesday then day_number = 2
-    when :wednesday then day_number = 3
-    when :thursday then day_number = 4
-    when :friday then day_number = 5
-    when :saturday then day_number = 6
-    when :sunday then day_number = 7
-    end
-
     # Get the first of the month
     first_of_month = Date.new(@year, @month, 1)
 
-    # Find first occurance of day_of_week
+    # Find first occurance of day_of_week. Try from the the 1st to the 7th
     first_occurance = nil
     7.times do |counter|
-      first_occurance = first_of_month + counter if (first_of_month + counter).cwday == day_number
+      first_occurance = first_of_month + counter if (first_of_month + counter).send("#{day_of_week}?")
     end
     first_occurance
+  end
+
+  def get_all_occurances(day_of_week)
+    first_occurance = get_first_occurance(day_of_week)
+    all_occurances = []
+    5.times do |week_num|
+      # Verify that it hasn't rolled into the next month
+      if (first_occurance + (7 * week_num)).mon == first_occurance.mon
+        all_occurances << (first_occurance + (7 * week_num))
+      end
+    end
+    all_occurances
   end
 end

--- a/exercism/ruby/meetup/meetup.rb
+++ b/exercism/ruby/meetup/meetup.rb
@@ -8,31 +8,34 @@ require 'Date'
 
 # Meetup Class determines the dates of meetings
 class Meetup
+  # constructor
   def initialize(month, year)
     @month = month
     @year = year
   end
 
+  # get meeting date
   def day(day_of_week, descriptor)
+    # Get first occurance of x day of the week in @month @year
     first_occurance = get_first_occurance(day_of_week)
 
     # handle descriptors
     case descriptor
+    # Simple handling of first to fourth
     when :first then first_occurance
     when :second then first_occurance + 7
     when :third then first_occurance + 14
     when :fourth then first_occurance + 21
+
     when :last
       # Aim high and work backwards until the months are the same
       if (first_occurance + 28).mon == first_occurance.mon
         first_occurance + 28
-      elsif (first_occurance + 21).mon == first_occurance.mon
-        first_occurance + 21
       else
-        first_occurance + 14
+        first_occurance + 21
       end
     when :teenth
-      # Test the sencond and third occurance of the day
+      # Test the sencond and third occurance of xday
       (1..2).each do |counter|
         loop_day_of_week = first_occurance + (counter * 7)
         return first_occurance + (counter * 7) if loop_day_of_week.day >= 13

--- a/exercism/ruby/meetup/meetup_test.rb
+++ b/exercism/ruby/meetup/meetup_test.rb
@@ -2,6 +2,8 @@ require 'minitest/autorun'
 require_relative 'meetup'
 
 class MeetupTest < Minitest::Test
+  # Why does it skip all of the tests? No problem, just override it 
+  def skip ; end
   def test_when_teenth_monday_is_the_13th_the_first_day_of_the_teenth_week
     # skip
     meetup = Meetup.new(5, 2013).day(:monday, :teenth)


### PR DESCRIPTION
Update:

I refactored and was able to fix the linting/complexity errors. One other issue that I fixed was `require 'Date'` instead of `require 'date'` which allowed tests to work locally but wouldn't pass online. I'd say that the current is in ideal form. Simple, efficient, readable, and few lines of code.


[First attempt 79fb59](https://github.com/HungryNomad/CodeChallenges/blob/79fb5923e2b481bb176e9b0e676b8b265ebb64f0/exercism/ruby/meetup/meetup.rb)

- Rubocop is throwing some errors. Do I really need to keep each method under 10 lines? And is a switch with 7 cases too much? It seems a bit excessive but I'd like your thoughts.
- All tests kept getting skipped over so I had to override the skip method... This probably is not the best way to solve it

Other than those 2 bits, it seems to run OK for my first try

```shell
Offenses:

meetup.rb:16:3: C: Metrics/AbcSize: Assignment Branch Condition size for day is too high. [<3, 19, 14> 23.79/17]
  def day(day_of_week, descriptor) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
meetup.rb:16:3: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for day is too high. [11/7]
  def day(day_of_week, descriptor) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
meetup.rb:16:3: C: Metrics/MethodLength: Method has too many lines. [20/10]
  def day(day_of_week, descriptor) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
meetup.rb:45:3: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for get_first_occurance is too high. [9/7]
  def get_first_occurance(day_of_week) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
meetup.rb:45:3: C: Metrics/MethodLength: Method has too many lines. [16/10]
  def get_first_occurance(day_of_week) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^```
  
